### PR TITLE
Update numpy and dash-daq versions.

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import dash_core_components as dcc
 from Phidget22.Devices.Accelerometer import Accelerometer
 app = dash.Dash()
 
-app.scripts.config.serve_locally = True
 app.config['suppress_callback_exceptions'] = True
 
 server = app.server

--- a/app_mock.py
+++ b/app_mock.py
@@ -11,7 +11,6 @@ from dash_daq import DarkThemeProvider
 
 app = dash.Dash()
 
-app.scripts.config.serve_locally = True
 app.config['suppress_callback_exceptions'] = True
 
 server = app.server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 gunicorn>=19.7.1
 plotly==3.5.0
 dash==0.36.0
-dash-daq==0.1.0
+dash-daq==0.1.1
 dash-renderer==0.17.0
 dash-html-components==0.13.5
 dash-core-components==0.43.0
-numpy==1.15.1
+numpy==1.16.1
 pylint
 flake8
 Phidget22==1.0.0


### PR DESCRIPTION
Newest version of dash-daq allows for not serving scripts locally, as dash-daq is now published on npm.